### PR TITLE
Fixes #14 - Handle sub-millisecond date precision in coercion

### DIFF
--- a/Date.js
+++ b/Date.js
@@ -1,5 +1,7 @@
-const isoDateFormat =
-    /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d+))?(Z)?$/;
+function coerceDateString (value) {
+  const parsed = Date.parse(value);
+  return isNaN(parsed) ? null : new Date(parsed);
+}
 
 module.exports = require('./Model').extend({
   typeName: 'date',
@@ -15,21 +17,7 @@ module.exports = require('./Model').extend({
 
     if (value != null) {
       if (value.constructor === String) {
-        const a = isoDateFormat.exec(value);
-        if (a) {
-          let millisecond = a[7];
-          millisecond = (millisecond === undefined) ? 0 : +millisecond;
-
-          if (a[8] === 'Z') {
-            // The `Z` suffix is used to indicate UTC time zone
-            value = new Date(Date.UTC(+a[1], +a[2] - 1, +a[3], +a[4], +a[5], +a[6], millisecond));
-          } else {
-            // No `Z` suffix so implicitly use time zone of this computer
-            value = new Date(+a[1], +a[2] - 1, +a[3], +a[4], +a[5], +a[6], millisecond);
-          }
-        } else {
-          return null;
-        }
+        return coerceDateString(value);
       } else if (value.constructor === Number) {
         value = new Date(value);
       } else if (value.constructor === Date) {

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -81,6 +81,28 @@ test('should handle Date type', function (t) {
   t.deepEqual(person.getDateOfBirth(), new Date(1980, 1, 1));
 });
 
+test('should coerce date with sub-millisecond precision when using static date coercion', function (t) {
+  const date = DateType.coerce('2022-01-10T21:15:41.573740635Z');
+  t.deepEqual(date.getTime(), 1641849341573);
+});
+
+test('should coerce date with sub-millisecond precision when using model getter/setter', function (t) {
+  const Document = Model.extend({
+    properties: {
+      dateCreated: Date
+    }
+  });
+
+  const document = new Document();
+  document.setDateCreated('2022-01-10T21:15:41.573740635Z');
+  t.deepEqual(document.getDateCreated().getTime(), 1641849341573);
+});
+
+test('should return null if invalid date supplied to date coercion', function (t) {
+  const date = DateType.coerce('invalid date');
+  t.deepEqual(date, null);
+});
+
 test('should serialize and deserialize date properly', function (t) {
   const date = new Date();
 


### PR DESCRIPTION
Leverage the native `Date.parse` function to handle `Date`
coercion when the source type is a string. This handles the
case when the supplied string was generated with sub-millisecond
precision.

@cfbevan @bishopb